### PR TITLE
Modularize "script" directory

### DIFF
--- a/script/__init__.py
+++ b/script/__init__.py
@@ -1,0 +1,3 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
CR_HW.py を外部からインポートする際に、 CR.py の import に失敗する問題がありました。
そこで、script ディレクトリ下をモジュールとし、検索パスを追加するよう修正してみました。